### PR TITLE
docs: update clone instructions to use Dirty-Dan

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The game is written in pure Python and runs directly from source—no binaries
 are required.  Download the code and install the only dependency, `pygame`:
 
 ```bash
-git clone https://github.com/<user>/LightBike
+git clone https://github.com/Dirty-Dan/LightBike
 cd LightBike
 pip install -r requirements.txt
 ```


### PR DESCRIPTION
## Summary
- replace user placeholder in README with Dirty-Dan for cloning instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3c93784cc832aac2b04fd9421c667