### PR TITLE
Add authoritative online multiplayer mode with server and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Neon Circuit
 
-**Neon Circuit** is a polished, local-multiplayer light-bike arena game inspired by classic Tron gameplay.
+**Neon Circuit** is a polished light-bike arena game inspired by classic Tron gameplay, with both local and online multiplayer modes.
 It is built with **Python + Pygame** for fast development and easy cross-platform packaging for **Windows** and **Linux**.
 
 ## Features
 
 - 2 to 4 local players on one machine
+- Online multiplayer over LAN/Internet (authoritative server + thin clients)
 - Continuous forward bike movement with 90° left/right turns
 - Solid light trails with instant elimination on collision
 - Round-based gameplay with persistent scoreboard
@@ -61,6 +62,25 @@ You can also launch with:
 python -m neon_circuit
 ```
 
+
+## Online Multiplayer
+
+Run one server and connect 2-4 clients:
+
+```bash
+# Terminal 1 (host/server)
+python server.py --host 0.0.0.0 --port 25565
+
+# Terminal 2+ (each player)
+python client.py --host <SERVER_IP> --port 25565
+```
+
+Online controls:
+
+- `A`/`D` or `Left`/`Right` = queue turn
+- `S` = start round (any connected player can start when 2+ players are present)
+- `ESC` = quit client
+
 ## Build Executables (Windows and Linux)
 
 > Build on each target OS to produce native executables.
@@ -108,8 +128,8 @@ LightBike/
 │   ├── config.py             # Tunables, controls, palettes
 │   ├── gameplay.py           # Bike movement, trails, collisions
 │   └── rendering.py          # Neon UI + arena drawing helpers
-├── server.py                 # Legacy network prototype (unused)
-└── client.py                 # Legacy network prototype (unused)
+├── server.py                 # Authoritative online multiplayer server
+└── client.py                 # Online multiplayer client
 ```
 
 ## Extensibility Notes

--- a/client.py
+++ b/client.py
@@ -1,84 +1,150 @@
-"""Pygame client for the networked Light Bike game."""
+"""Online multiplayer client for Neon Circuit."""
 
+from __future__ import annotations
+
+import argparse
 import json
 import socket
-from typing import Dict
+from typing import Any, Optional
 
 import pygame
 
-SERVER_HOST = "127.0.0.1"  # Change to the server's IP when playing remotely
-PORT = 25565
+from neon_circuit.config import GRID_SIZE, SCREEN_HEIGHT, SCREEN_WIDTH
+
+SERVER_HOST = "127.0.0.1"
+SERVER_PORT = 25565
 
 
-def send(sock: socket.socket, message: Dict[str, str]) -> None:
-    sock.sendall(json.dumps(message).encode("utf-8"))
+def send_json(sock: socket.socket, payload: dict[str, Any]) -> None:
+    sock.sendall((json.dumps(payload) + "\n").encode("utf-8"))
 
 
-buffer = b""
+class SocketReader:
+    def __init__(self) -> None:
+        self.buffer = b""
 
-
-def receive(sock: socket.socket) -> Dict[str, object] | None:
-    """Receive a single JSON message terminated by a newline."""
-    global buffer
-    try:
-        chunk = sock.recv(4096)
-        if not chunk:
+    def recv_json(self, sock: socket.socket) -> Optional[dict[str, Any]]:
+        try:
+            chunk = sock.recv(4096)
+        except BlockingIOError:
             return None
-        buffer += chunk
-    except BlockingIOError:
-        return None
-    if b"\n" not in buffer:
-        return None
-    line, buffer = buffer.split(b"\n", 1)
-    return json.loads(line.decode("utf-8"))
+        if not chunk:
+            raise ConnectionError("Server disconnected")
+        self.buffer += chunk
+        if b"\n" not in self.buffer:
+            return None
+        line, self.buffer = self.buffer.split(b"\n", 1)
+        return json.loads(line.decode("utf-8"))
 
 
-def main() -> None:
-    # ----------------------------------------------------------------- network
+def draw_text(screen: pygame.Surface, font: pygame.font.Font, txt: str, x: int, y: int, color=(220, 220, 220)) -> None:
+    surf = font.render(txt, True, color)
+    screen.blit(surf, (x, y))
+
+
+def cell_to_px(cell: list[int]) -> tuple[int, int]:
+    return (cell[0] * GRID_SIZE + GRID_SIZE // 2, cell[1] * GRID_SIZE + GRID_SIZE // 2)
+
+
+def run_client(host: str, port: int) -> None:
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.connect((SERVER_HOST, PORT))
+    sock.connect((host, port))
     sock.setblocking(False)
 
-    # ------------------------------------------------------------------ pygame
+    reader = SocketReader()
+    my_index: Optional[int] = None
+    state: dict[str, Any] = {"mode": "lobby", "players": [], "scores": {}, "message": "Connecting..."}
+
     pygame.init()
-    screen = pygame.display.set_mode((800, 600))
-    pygame.display.set_caption("Light Bike")
+    screen = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT))
+    pygame.display.set_caption("Neon Circuit Online")
     clock = pygame.time.Clock()
+    title_font = pygame.font.SysFont("consolas", 34)
+    text_font = pygame.font.SysFont("consolas", 22)
 
     running = True
     while running:
-        # Handle input events
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 running = False
+            elif event.type == pygame.KEYDOWN:
+                if event.key == pygame.K_ESCAPE:
+                    running = False
+                elif event.key in (pygame.K_a, pygame.K_LEFT):
+                    send_json(sock, {"action": "turn", "dir": -1})
+                elif event.key in (pygame.K_d, pygame.K_RIGHT):
+                    send_json(sock, {"action": "turn", "dir": 1})
+                elif event.key == pygame.K_s:
+                    send_json(sock, {"action": "start"})
 
-        keys = pygame.key.get_pressed()
-        if keys[pygame.K_LEFT]:
-            send(sock, {"action": "move", "direction": "left"})
-        elif keys[pygame.K_RIGHT]:
-            send(sock, {"action": "move", "direction": "right"})
-        elif keys[pygame.K_UP]:
-            send(sock, {"action": "move", "direction": "up"})
-        elif keys[pygame.K_DOWN]:
-            send(sock, {"action": "move", "direction": "down"})
+        while True:
+            try:
+                msg = reader.recv_json(sock)
+            except ConnectionError:
+                state["message"] = "Disconnected from server"
+                running = False
+                break
 
-        # ---------------------------------------------------------------- draw
-        state = receive(sock)
-        if state:
-            screen.fill((0, 0, 0))
-            for player in state["players"].values():
-                color = tuple(player["color"])
-                for point in player.get("trail", []):
-                    pygame.draw.rect(screen, color, (point["x"], point["y"], 10, 10))
-                pygame.draw.rect(screen, color, (player["x"], player["y"], 10, 10))
-            pygame.display.flip()
+            if msg is None:
+                break
+            if msg.get("type") == "welcome":
+                my_index = int(msg["player_index"])
+            elif msg.get("type") == "state":
+                state = msg
 
+        screen.fill((7, 7, 18))
+
+        # Grid
+        for x in range(0, SCREEN_WIDTH, GRID_SIZE * 2):
+            pygame.draw.line(screen, (20, 20, 42), (x, 0), (x, SCREEN_HEIGHT))
+        for y in range(0, SCREEN_HEIGHT, GRID_SIZE * 2):
+            pygame.draw.line(screen, (20, 20, 42), (0, y), (SCREEN_WIDTH, y))
+
+        draw_text(screen, title_font, "NEON CIRCUIT ONLINE", 24, 20, (0, 255, 255))
+        draw_text(screen, text_font, f"Server: {host}:{port}", 24, 66)
+        draw_text(screen, text_font, "Controls: A/D or Left/Right to turn, S to start", 24, 92)
+
+        if my_index is not None:
+            draw_text(screen, text_font, f"You are Player {my_index + 1}", 24, 118, (255, 220, 120))
+
+        # Players and trails
+        for p in state.get("players", []):
+            bike = p.get("bike")
+            if not bike:
+                continue
+            color = tuple(bike["color"])
+            trail = bike["trail"]
+            for i in range(1, len(trail)):
+                pygame.draw.line(screen, color, cell_to_px(trail[i - 1]), cell_to_px(trail[i]), 3)
+            head_pos = cell_to_px(bike["pos"])
+            radius = 7 if bike.get("alive", False) else 5
+            head_color = color if bike.get("alive", False) else (110, 110, 110)
+            pygame.draw.circle(screen, head_color, head_pos, radius)
+
+            label = f"P{p['index'] + 1}: {p['name']}"
+            draw_text(screen, text_font, label, 24, 170 + p["index"] * 24, color)
+
+        # Scoreboard
+        scores = state.get("scores", {})
+        score_parts = [f"P{i + 1}:{scores.get(str(i), 0)}" for i in range(4)]
+        draw_text(screen, text_font, "Scores " + "  ".join(score_parts), 24, SCREEN_HEIGHT - 50)
+        draw_text(screen, text_font, f"Mode: {state.get('mode', 'unknown')}", SCREEN_WIDTH - 260, 24, (180, 220, 255))
+        draw_text(screen, text_font, state.get("message", ""), 24, SCREEN_HEIGHT - 80, (220, 200, 255))
+
+        pygame.display.flip()
         clock.tick(60)
 
     pygame.quit()
     sock.close()
 
 
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Neon Circuit online client")
+    parser.add_argument("--host", default=SERVER_HOST)
+    parser.add_argument("--port", type=int, default=SERVER_PORT)
+    args = parser.parse_args()
+    run_client(args.host, args.port)
+
+
 if __name__ == "__main__":
     main()
-

--- a/server.py
+++ b/server.py
@@ -1,156 +1,272 @@
-"""Minimal socket server for the Light Bike game.
+"""Authoritative online multiplayer server for Neon Circuit.
 
-This server keeps track of every connected player and broadcasts the game
-state to all clients on every update.  Each client only sends movement
-commands; the authoritative position is maintained here.  The protocol is a
-simple JSON message:
-
-    {"action": "move", "direction": "left"}
-
-The game state that is sent back looks like:
-
-    {"players": {"player1": {"x": 10, "y": 20, "color": [255,0,0],
-                             "trail": [{"x":10,"y":20}, ...]}, ...}}
-
-Running this module launches the server on port 25565.
+Protocol (newline-delimited JSON):
+- Client -> server:
+    {"action": "join", "name": "Alice"}
+    {"action": "turn", "dir": -1|1}
+    {"action": "start"}
+- Server -> client:
+    {
+      "type": "welcome",
+      "player_index": 0,
+      "name": "Alice"
+    }
+    {
+      "type": "state",
+      "mode": "lobby"|"playing"|"round_over",
+      "players": [...],
+      "scores": {"0": 1, ...},
+      "message": "..."
+    }
 """
 
 from __future__ import annotations
 
+import argparse
 import json
-import select
 import socket
-from typing import Dict, List, Tuple
+import threading
+import time
+from dataclasses import dataclass
+from typing import Dict, Optional
 
-HOST = "0.0.0.0"
-PORT = 25565
-STEP = 5  # distance moved per command
+from neon_circuit.config import COLOR_PRESETS, SOUND_PRESETS
+from neon_circuit.gameplay import ArenaRound, PlayerConfig
+
+DEFAULT_HOST = "0.0.0.0"
+DEFAULT_PORT = 25565
+MAX_PLAYERS = 4
 
 
-class LightBikeServer:
-    """TCP server handling multiple Light Bike clients."""
+@dataclass
+class ClientInfo:
+    sock: socket.socket
+    addr: tuple[str, int]
+    name: str
+    player_index: int
 
-    def __init__(self) -> None:
+
+class NeonCircuitServer:
+    def __init__(self, host: str, port: int, tick_rate: int = 30) -> None:
+        self.host = host
+        self.port = port
+        self.tick_rate = tick_rate
+
         self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        # Allow fast restart during development
         self.server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self.server_socket.bind((HOST, PORT))
+        self.server_socket.bind((self.host, self.port))
         self.server_socket.listen()
 
-        # Mapping of socket -> player id
-        self._socket_to_pid: Dict[socket.socket, str] = {}
+        self.clients: Dict[socket.socket, ClientInfo] = {}
+        self.scores: Dict[int, int] = {i: 0 for i in range(MAX_PLAYERS)}
+        self.lock = threading.Lock()
 
-        # Game state sent to every client
-        self.players: Dict[str, Dict[str, object]] = {}
-        self.next_id = 1
+        self.round: Optional[ArenaRound] = None
+        self.mode = "lobby"
+        self.round_over_time: float = 0.0
 
-        self.sockets: List[socket.socket] = [self.server_socket]
+    def _make_player_config(self, idx: int) -> PlayerConfig:
+        return PlayerConfig(
+            index=idx,
+            color=COLOR_PRESETS[idx % len(COLOR_PRESETS)],
+            sound_profile=SOUND_PRESETS[idx % len(SOUND_PRESETS)],
+            controls={},
+        )
 
-        # Predefined colours for up to four players
-        self.colours: List[Tuple[int, int, int]] = [
-            (255, 0, 0),    # red
-            (0, 0, 255),    # blue
-            (0, 255, 0),    # green
-            (255, 255, 0),  # yellow
-        ]
+    def _active_player_configs(self) -> list[PlayerConfig]:
+        indices = sorted(info.player_index for info in self.clients.values())
+        return [self._make_player_config(idx) for idx in indices]
 
-    # ------------------------------------------------------------------ utils
-    def _broadcast(self) -> None:
-        """Send the entire game state to every connected client."""
-        data = (json.dumps({"players": self.players}) + "\n").encode("utf-8")
-        for sock in list(self.sockets):
-            if sock is self.server_socket:
-                continue
-            try:
-                sock.sendall(data)
-            except OSError:
-                # If sending fails, drop the client
-                self._remove_client(sock)
+    def _start_round(self) -> None:
+        configs = self._active_player_configs()
+        if len(configs) < 2:
+            return
+        self.round = ArenaRound(configs)
+        self.mode = "playing"
 
-    def _remove_client(self, sock: socket.socket) -> None:
-        pid = self._socket_to_pid.pop(sock, None)
-        if pid and pid in self.players:
-            del self.players[pid]
-        if sock in self.sockets:
-            self.sockets.remove(sock)
+    def _serialize_state(self, message: str = "") -> dict[str, object]:
+        players = []
+        by_index = {c.player_index: c for c in self.clients.values()}
+
+        for idx, info in sorted(by_index.items()):
+            bike_payload = None
+            if self.round:
+                for bike in self.round.bikes:
+                    if bike.config.index == idx:
+                        bike_payload = {
+                            "pos": [bike.pos[0], bike.pos[1]],
+                            "trail": [[t[0], t[1]] for t in bike.trail],
+                            "alive": bike.alive,
+                            "color": list(bike.config.color),
+                        }
+                        break
+
+            players.append(
+                {
+                    "index": idx,
+                    "name": info.name,
+                    "bike": bike_payload,
+                }
+            )
+
+        return {
+            "type": "state",
+            "mode": self.mode,
+            "players": players,
+            "scores": {str(k): v for k, v in self.scores.items()},
+            "message": message,
+        }
+
+    def _send_json(self, sock: socket.socket, payload: dict[str, object]) -> bool:
+        try:
+            sock.sendall((json.dumps(payload) + "\n").encode("utf-8"))
+            return True
+        except OSError:
+            return False
+
+    def _broadcast_state(self, message: str = "") -> None:
+        payload = self._serialize_state(message)
+        dead = []
+        for sock in self.clients:
+            if not self._send_json(sock, payload):
+                dead.append(sock)
+        for sock in dead:
+            self._drop_client(sock)
+
+    def _drop_client(self, sock: socket.socket) -> None:
+        info = self.clients.pop(sock, None)
         try:
             sock.close()
-        finally:
-            self._broadcast()
+        except OSError:
+            pass
+        if info:
+            print(f"[-] Player disconnected: {info.name} ({info.addr[0]}:{info.addr[1]})")
+            if self.mode == "playing" and self.round:
+                for bike in self.round.bikes:
+                    if bike.config.index == info.player_index:
+                        bike.alive = False
+                        self.round._finalize_result()  # keep server deterministic
+                        break
 
-    # ----------------------------------------------------------------- accept
-    def _accept_new_client(self) -> None:
-        client_socket, _ = self.server_socket.accept()
-        self.sockets.append(client_socket)
-
-        pid = f"player{self.next_id}"
-        self._socket_to_pid[client_socket] = pid
-
-        # Place players at slightly different starting positions
-        start_x = 50 + 100 * ((self.next_id - 1) % 4)
-        start_y = 50 + 100 * ((self.next_id - 1) // 4)
-        colour = self.colours[(self.next_id - 1) % len(self.colours)]
-
-        self.players[pid] = {
-            "x": start_x,
-            "y": start_y,
-            "color": list(colour),
-            "trail": [],
-        }
-        self.next_id += 1
-        self._broadcast()
-
-    # ------------------------------------------------------------- client data
-    def _handle_client(self, sock: socket.socket) -> None:
+    def _handle_line(self, sock: socket.socket, line: bytes) -> None:
         try:
-            data = sock.recv(1024)
-            if not data:
-                # Client disconnected
-                self._remove_client(sock)
-                return
-            message = json.loads(data.decode("utf-8"))
-        except Exception:
-            self._remove_client(sock)
+            msg = json.loads(line.decode("utf-8"))
+        except json.JSONDecodeError:
             return
 
-        pid = self._socket_to_pid.get(sock)
-        if not pid:
-            return
-        player = self.players.get(pid)
-        if not player:
+        action = msg.get("action")
+        info = self.clients.get(sock)
+        if not info:
             return
 
-        if message.get("action") == "move":
-            direction = message.get("direction")
-            if direction == "left":
-                player["x"] -= STEP
-            elif direction == "right":
-                player["x"] += STEP
-            elif direction == "up":
-                player["y"] -= STEP
-            elif direction == "down":
-                player["y"] += STEP
+        if action == "turn" and self.mode == "playing" and self.round:
+            dir_value = int(msg.get("dir", 0))
+            if dir_value in (-1, 1):
+                self.round.queue_turn(info.player_index, dir_value)
 
-            player["trail"].append({"x": player["x"], "y": player["y"]})
+        elif action == "start" and self.mode == "lobby":
+            if len(self.clients) >= 2:
+                self._start_round()
+                self._broadcast_state("Round started")
 
-        self._broadcast()
+    def _client_thread(self, sock: socket.socket) -> None:
+        buff = b""
+        try:
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                buff += chunk
+                while b"\n" in buff:
+                    line, buff = buff.split(b"\n", 1)
+                    if line.strip():
+                        with self.lock:
+                            self._handle_line(sock, line)
+        except OSError:
+            pass
+        finally:
+            with self.lock:
+                self._drop_client(sock)
+                self._broadcast_state()
 
-    # ------------------------------------------------------------------- main
-    def serve_forever(self) -> None:
-        print(f"Server started on {HOST}:{PORT}")
+    def _accept_clients_forever(self) -> None:
         while True:
-            readable, _, _ = select.select(self.sockets, [], [])
-            for sock in readable:
-                if sock is self.server_socket:
-                    self._accept_new_client()
+            sock, addr = self.server_socket.accept()
+            with self.lock:
+                if len(self.clients) >= MAX_PLAYERS:
+                    self._send_json(sock, {"type": "error", "message": "Lobby is full (max 4 players)."})
+                    sock.close()
+                    continue
+
+                player_index = 0
+                used = {client.player_index for client in self.clients.values()}
+                while player_index in used:
+                    player_index += 1
+
+                self._send_json(sock, {"type": "welcome", "player_index": player_index})
+
+                sock.settimeout(None)
+                info = ClientInfo(
+                    sock=sock,
+                    addr=addr,
+                    name=f"Player {player_index + 1}",
+                    player_index=player_index,
+                )
+                self.clients[sock] = info
+                print(f"[+] Player connected: {info.name} ({addr[0]}:{addr[1]})")
+                self._broadcast_state("Player joined")
+
+            thread = threading.Thread(target=self._client_thread, args=(sock,), daemon=True)
+            thread.start()
+
+    def _game_loop(self) -> None:
+        last = time.perf_counter()
+        while True:
+            now = time.perf_counter()
+            dt = now - last
+            last = now
+
+            with self.lock:
+                if self.mode == "playing" and self.round:
+                    result = self.round.update(dt)
+                    if result:
+                        self.mode = "round_over"
+                        if result.winner is not None:
+                            self.scores[result.winner] += 1
+                        self.round_over_time = time.perf_counter()
+                        self._broadcast_state(result.message)
+                    else:
+                        self._broadcast_state()
+                elif self.mode == "round_over":
+                    self._broadcast_state("Round over - restarting in 3 seconds")
+                    if time.perf_counter() - self.round_over_time >= 3.0:
+                        if len(self.clients) >= 2:
+                            self._start_round()
+                            self._broadcast_state("New round")
+                        else:
+                            self.mode = "lobby"
+                            self.round = None
                 else:
-                    self._handle_client(sock)
+                    self._broadcast_state("Waiting for 2+ players. Host presses S to start.")
+
+            time.sleep(1.0 / self.tick_rate)
+
+    def serve_forever(self) -> None:
+        print(f"Neon Circuit server listening on {self.host}:{self.port}")
+        accept_thread = threading.Thread(target=self._accept_clients_forever, daemon=True)
+        accept_thread.start()
+        self._game_loop()
 
 
 def main() -> None:
-    LightBikeServer().serve_forever()
+    parser = argparse.ArgumentParser(description="Neon Circuit online multiplayer server")
+    parser.add_argument("--host", default=DEFAULT_HOST)
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    args = parser.parse_args()
+
+    server = NeonCircuitServer(args.host, args.port)
+    server.serve_forever()
 
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
### Motivation

- Provide online multiplayer so players can host a server and connect thin clients over LAN/Internet. 
- Make the server authoritative so game state (positions, trails, collisions, rounds) is deterministic and consistent for all clients. 

### Description

- Replace the lightweight prototype networking with a full `NeonCircuitServer` in `server.py` that uses `ArenaRound` as the authoritative simulation and broadcasts newline-delimited JSON state snapshots (`lobby` / `playing` / `round_over`).
- Add a new online client in `client.py` that connects via CLI flags, handles `welcome` and `state` messages, sends `turn`/`start` actions, and renders grid, trails, bike heads, player labels, and a scoreboard. 
- Support up to 4 players with server-side player indexing, deterministic turn queuing (`ArenaRound.queue_turn`), collision resolution, scoring, and automatic round restarts. 
- Update `README.md` to document the online workflow and include example commands to run the server and clients (`python server.py --host 0.0.0.0 --port 25565` and `python client.py --host <SERVER_IP> --port 25565`).

### Testing

- Compiled the runtime files with `python -m py_compile server.py client.py neon_circuit/*.py LightBike.py`, which completed without errors. 
- Ran `pytest -q`, which reported no tests were defined in the repository (no tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5f734b86c832ab9f9c41fd377de8a)